### PR TITLE
updates to the printCards function to improve look and usefulness

### DIFF
--- a/sappyspellbook/bard/index.html
+++ b/sappyspellbook/bard/index.html
@@ -18,6 +18,8 @@
 
   gtag('config', 'G-7JR53Y27TN');
 </script>
+<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"></script>
+
 </head>
 <body>
     <div class="topnav">
@@ -481,8 +483,10 @@
          </table>
        </div>
     
+      <div hidden id="qrcode"></div>
     
   <div id="toastMessage" class="toast"></div>
+
 <!-- partial -->
   <script  src="./script.js"></script>
   <footer>

--- a/sappyspellbook/bard/script.js
+++ b/sappyspellbook/bard/script.js
@@ -189,6 +189,16 @@ function toggleIncants(){
 }
 /*##################################*/
 function toggleList(incantOnly){
+
+  const qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: window.location.href,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1748,10 +1758,10 @@ function getAbilities(){return abilities}
 function saveList(){
   let textToSave = "";
   if(document.title == "Bard Spellbook"){
-    textToSave = "Bard Level " + document.getElementById("reqLevel").value + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = "Bard Level " + document.getElementById("reqLevel").value + document.getElementById("ltp").innerText + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   else{
-    textToSave = document.title + " \n(Bard Level " + document.getElementById("reqLevel").value + ")" + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = document.title + " \n(Bard Level " + document.getElementById("reqLevel").value + ")" + document.getElementById("ltp").innerText + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }    
   const blob = new Blob([textToSave], { type: 'text/plain' });
   const link = document.createElement('a');
@@ -1767,14 +1777,15 @@ function printCards(){
     toggleIncants();
   }
   if(document.title == "Bard Spellbook"){
-    textToSave = "Bard Level " + document.getElementById("reqLevel").value + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = "Bard Level " + document.getElementById("reqLevel").value + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   else{
-    textToSave = document.title + " \n(Bard Level " + document.getElementById("reqLevel").value + ")" + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = document.title + " (Bard Level " + document.getElementById("reqLevel").value + ")" + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   const textData = textToSave;
 
-  const lines = textData.split('\n');
+  const lines = textData.split('\n'); // this is "lines" but it's not column-limited! Limit to 69 (nice) characters to prevent wrap
+
   const title = lines[0];
   const entries = [];
 
@@ -1783,7 +1794,7 @@ function printCards(){
     const line = lines[i].trim();
     if (line.startsWith('Level')) {
       currentLevel = line;
-    } else if (line.includes('Experienced')) {
+    } else if (line.includes('Experienced')) { // roll purchases of Experienced into the spell it's purchased for to avoide wasting space on the card
     } else if (line.startsWith('-')) {
     if (entries.length > 0) {
         entries[entries.length - 1].flavor = line.slice(1).trim();
@@ -1802,7 +1813,9 @@ function printCards(){
         entries.splice(j,j)
       }
    }
-   if ([entries[i].text + entries[i].flavor].length + 3 >79){
+   txt = entries[i].text
+   flv = entries[i].flavor
+   if (txt.length + flv.length + 6 > 66){
      entries[i].lines = 2
    } else {entries[i].lines = 1}
  }
@@ -1810,31 +1823,49 @@ function printCards(){
 
 // Split onto up to 3 cards
 numchunks = 3
-maxchunlines = 10 // this may be right for 9pt
+maxchunlines = 14 // this may be right for 9pt
 chunks = []
 currchlines = 0
 cut = []
 for (let i = 0; i < entries.length; i++) {
   currchlines = currchlines + entries[i].lines
-  // console.log(currchlines)
+  console.log(currchlines)
   if (currchlines >= maxchunlines){
     cut.push(i)
-    // console.log(i)
+    console.log(entries[i].lines)
     currchlines = entries[i].lines
   }
 }
 console.log(cut)
 console.log(cut.length)
 
+chunks.push({num: 1, max: 1, qr: true, entries: []})
+
 if (cut.length == 1){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1])];
+  divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 2, qr: false, entries: divs[1]})
+  chunks[0].max = 2
 }
 else if (cut.length == 2){
-chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1]), entries.slice(cut[1])];
-} 
+divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1, cut[1]-1), entries.slice(cut[1]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 3, qr: false, entries: divs[1]})
+  chunks.push({num: 3, max: 3, qr: false, entries: divs[2]})
+  chunks[0].max = 3} 
 else {
-chunks = [entries];
+divs = [entries];
+chunks[0].entries = divs
 }
+console.log(chunks)
+
+
+
+// get the qr and put it where it goes 
+var qr = document.getElementById('qrcode')
+var qrcanvas = qr.querySelector('canvas');
+console.log(qrcanvas) // wtf
+qrImageSrc = qrcanvas.toDataURL();
 
 const htmlContent = `
 <html>
@@ -1873,9 +1904,10 @@ const htmlContent = `
 <body>
   ${chunks.map(chunk => `
     <div class="card">
-      <div class="title">${title}</div>
-    ${chunk.map(entry => `
-        <div class="entry">${entry.text}${entry.flavor ? ' - ' + entry.flavor : ''}</div>
+    <img ${chunk.num == 1 ? '' : 'hidden '}style="float: right; width: 60px; height: auto" src=${qrImageSrc}></img>
+      <div class="title"><u>${title}</u>  ${chunk.num}/${chunk.max}</div> 
+      ${chunk.entries.map(entry => `
+        <div class="entry"><b>${entry.text}</b><i>${entry.flavor ? ' - ' + entry.flavor : ''}</i></div>
       `).join('')}
     </div>
     `).join('')}
@@ -1888,6 +1920,12 @@ const blob = new Blob([htmlContent], { type: 'text/html' });
 const url = URL.createObjectURL(blob);
 window.open(url, '_blank');
 }
+
+
+
+
+
+
 
 function titleList(){
   let newTitle = prompt("Enter a title for this list:");

--- a/sappyspellbook/bard/script.js
+++ b/sappyspellbook/bard/script.js
@@ -1823,7 +1823,7 @@ function printCards(){
 
 // Split onto up to 3 cards
 numchunks = 3
-maxchunlines = 14 // this may be right for 9pt
+maxchunlines = 13 // this may be right for 9pt
 chunks = []
 currchlines = 0
 cut = []

--- a/sappyspellbook/druid/index.html
+++ b/sappyspellbook/druid/index.html
@@ -15,6 +15,8 @@
 
   gtag('config', 'G-7JR53Y27TN');
 </script>
+<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"></script>
+
 </head>
 <body>
 <!-- partial:index.partial.html -->
@@ -526,6 +528,8 @@
        </table>
      </div>
   
+        <div hidden id="qrcode"></div>
+
   
 <div id="toastMessage" class="toast"></div>
 <!-- partial -->

--- a/sappyspellbook/druid/script.js
+++ b/sappyspellbook/druid/script.js
@@ -151,6 +151,16 @@ function toggleIncants(){
 }
 /*##################################*/
 function toggleList(incantOnly){
+
+  const qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: window.location.href,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1625,14 +1635,15 @@ function printCards(){
     toggleIncants();
   }
   if(document.title == "Druid Spellbook"){
-    textToSave = "Druid Level " + document.getElementById("reqLevel").value + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = "Druid Level " + document.getElementById("reqLevel").value + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   else{
-    textToSave = document.title + " \n(Druid Level " + document.getElementById("reqLevel").value + ")" + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = document.title + " (Druid Level " + document.getElementById("reqLevel").value + ")" + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   const textData = textToSave;
 
-  const lines = textData.split('\n');
+  const lines = textData.split('\n'); // this is "lines" but it's not column-limited! Limit to 69 (nice) characters to prevent wrap
+
   const title = lines[0];
   const entries = [];
 
@@ -1641,9 +1652,9 @@ function printCards(){
     const line = lines[i].trim();
     if (line.startsWith('Level')) {
       currentLevel = line;
-    } else if (line.includes('Experienced')) {
+    } else if (line.includes('Experienced')) { // roll purchases of Experienced into the spell it's purchased for to avoide wasting space on the card
     } else if (line.startsWith('-')) {
-      if (entries.length > 0) {
+    if (entries.length > 0) {
         entries[entries.length - 1].flavor = line.slice(1).trim();
       }
     } else if (line) {
@@ -1651,48 +1662,60 @@ function printCards(){
     }
   }
 
-// collapsing armor so it doesn't eat two lines
   for (let i = 0; i < entries.length; i++) {
-    for (let j = i + 1; j < entries.length; j++) {
-      if (entries[i].text === entries[j].text) {
-        // replace first instance with 2x iff there are two
-        entries[i] = { level: entries[i].level, text: entries[i].text.replace("1", "2"), flavor: entries[i].flavor };
-        entries.splice(j,j)
-      }
-    }
-    if ([entries[i].text + entries[i].flavor].length + 3 >79){
+   txt = entries[i].text
+   flv = entries[i].flavor
+   if (txt.length + flv.length + 6 > 66){
      entries[i].lines = 2
    } else {entries[i].lines = 1}
  }
 
 
 // Split onto up to 3 cards
- numchunks = 3
-maxchunlines = 10 // this may be right for 9pt
+numchunks = 3
+maxchunlines = 14 // this may be right for 9pt
 chunks = []
 currchlines = 0
 cut = []
 for (let i = 0; i < entries.length; i++) {
   currchlines = currchlines + entries[i].lines
-  // console.log(currchlines)
+  console.log(currchlines)
   if (currchlines >= maxchunlines){
     cut.push(i)
-    // console.log(i)
+    console.log(entries[i].lines)
     currchlines = entries[i].lines
   }
 }
 console.log(cut)
 console.log(cut.length)
 
+chunks.push({num: 1, max: 1, qr: true, entries: []})
+
 if (cut.length == 1){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1])];
+  divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 2, qr: false, entries: divs[1]})
+  chunks[0].max = 2
 }
 else if (cut.length == 2){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1]), entries.slice(cut[1])];
-} 
+divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1, cut[1]-1), entries.slice(cut[1]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 3, qr: false, entries: divs[1]})
+  chunks.push({num: 3, max: 3, qr: false, entries: divs[2]})
+  chunks[0].max = 3} 
 else {
-  chunks = [entries];
+divs = [entries];
+chunks[0].entries = divs
 }
+console.log(chunks)
+
+
+
+// get the qr and put it where it goes 
+var qr = document.getElementById('qrcode')
+var qrcanvas = qr.querySelector('canvas');
+console.log(qrcanvas) // wtf
+qrImageSrc = qrcanvas.toDataURL();
 
 const htmlContent = `
 <html>
@@ -1731,9 +1754,10 @@ const htmlContent = `
 <body>
   ${chunks.map(chunk => `
     <div class="card">
-      <div class="title">${title}</div>
-    ${chunk.map(entry => `
-        <div class="entry">${entry.text}${entry.flavor ? ' - ' + entry.flavor : ''}</div>
+    <img ${chunk.num == 1 ? '' : 'hidden '}style="float: right; width: 60px; height: auto" src=${qrImageSrc}></img>
+      <div class="title"><u>${title}</u>  ${chunk.num}/${chunk.max}</div> 
+      ${chunk.entries.map(entry => `
+        <div class="entry"><b>${entry.text}</b><i>${entry.flavor ? ' - ' + entry.flavor : ''}</i></div>
       `).join('')}
     </div>
     `).join('')}

--- a/sappyspellbook/healer/index.html
+++ b/sappyspellbook/healer/index.html
@@ -11,6 +11,8 @@
 
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-7JR53Y27TN"></script>
+<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"></script>
+
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -539,7 +541,8 @@
          </table>
        </div>
     
-    
+          <div hidden id="qrcode"></div>
+
   <div id="toastMessage" class="toast"></div>
 <!-- partial -->
 <footer>

--- a/sappyspellbook/healer/script.js
+++ b/sappyspellbook/healer/script.js
@@ -187,6 +187,15 @@ function toggleIncants(){
 }
 /*##################################*/
 function toggleList(incantOnly){
+  const qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: window.location.href,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1862,14 +1871,15 @@ function printCards(){
     toggleIncants();
   }
   if(document.title == "Healer Spellbook"){
-    textToSave = "Healer Level " + document.getElementById("reqLevel").value + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = "Healer Level " + document.getElementById("reqLevel").value + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   else{
-    textToSave = document.title + " \n(Healer Level " + document.getElementById("reqLevel").value + ")" + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = document.title + " (Healer Level " + document.getElementById("reqLevel").value + ")" + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   const textData = textToSave;
 
-  const lines = textData.split('\n');
+  const lines = textData.split('\n'); // this is "lines" but it's not column-limited! Limit to 69 (nice) characters to prevent wrap
+
   const title = lines[0];
   const entries = [];
 
@@ -1878,9 +1888,9 @@ function printCards(){
     const line = lines[i].trim();
     if (line.startsWith('Level')) {
       currentLevel = line;
-    } else if (line.includes('Experienced')) {
+    } else if (line.includes('Experienced')) { // roll purchases of Experienced into the spell it's purchased for to avoide wasting space on the card
     } else if (line.startsWith('-')) {
-      if (entries.length > 0) {
+    if (entries.length > 0) {
         entries[entries.length - 1].flavor = line.slice(1).trim();
       }
     } else if (line) {
@@ -1888,48 +1898,60 @@ function printCards(){
     }
   }
 
-// collapsing armor so it doesn't eat two lines
   for (let i = 0; i < entries.length; i++) {
-    for (let j = i + 1; j < entries.length; j++) {
-      if (entries[i].text === entries[j].text) {
-        // replace first instance with 2x iff there are two
-        entries[i] = { level: entries[i].level, text: entries[i].text.replace("1", "2"), flavor: entries[i].flavor };
-        entries.splice(j,j)
-      }
-    }
-    if ([entries[i].text + entries[i].flavor].length + 3 >79){
+   txt = entries[i].text
+   flv = entries[i].flavor
+   if (txt.length + flv.length + 6 > 66){
      entries[i].lines = 2
    } else {entries[i].lines = 1}
  }
 
 
 // Split onto up to 3 cards
- numchunks = 3
-maxchunlines = 10 // this may be right for 9pt
+numchunks = 3
+maxchunlines = 14 // this may be right for 9pt
 chunks = []
 currchlines = 0
 cut = []
 for (let i = 0; i < entries.length; i++) {
   currchlines = currchlines + entries[i].lines
-  // console.log(currchlines)
+  console.log(currchlines)
   if (currchlines >= maxchunlines){
     cut.push(i)
-    // console.log(i)
+    console.log(entries[i].lines)
     currchlines = entries[i].lines
   }
 }
 console.log(cut)
 console.log(cut.length)
 
+chunks.push({num: 1, max: 1, qr: true, entries: []})
+
 if (cut.length == 1){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1])];
+  divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 2, qr: false, entries: divs[1]})
+  chunks[0].max = 2
 }
 else if (cut.length == 2){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1]), entries.slice(cut[1])];
-} 
+divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1, cut[1]-1), entries.slice(cut[1]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 3, qr: false, entries: divs[1]})
+  chunks.push({num: 3, max: 3, qr: false, entries: divs[2]})
+  chunks[0].max = 3} 
 else {
-  chunks = [entries];
+divs = [entries];
+chunks[0].entries = divs
 }
+console.log(chunks)
+
+
+
+// get the qr and put it where it goes 
+var qr = document.getElementById('qrcode')
+var qrcanvas = qr.querySelector('canvas');
+console.log(qrcanvas) // wtf
+qrImageSrc = qrcanvas.toDataURL();
 
 const htmlContent = `
 <html>
@@ -1968,9 +1990,10 @@ const htmlContent = `
 <body>
   ${chunks.map(chunk => `
     <div class="card">
-      <div class="title">${title}</div>
-    ${chunk.map(entry => `
-        <div class="entry">${entry.text}${entry.flavor ? ' - ' + entry.flavor : ''}</div>
+    <img ${chunk.num == 1 ? '' : 'hidden '}style="float: right; width: 60px; height: auto" src=${qrImageSrc}></img>
+      <div class="title"><u>${title}</u>  ${chunk.num}/${chunk.max}</div> 
+      ${chunk.entries.map(entry => `
+        <div class="entry"><b>${entry.text}</b><i>${entry.flavor ? ' - ' + entry.flavor : ''}</i></div>
       `).join('')}
     </div>
     `).join('')}

--- a/sappyspellbook/wizard/index.html
+++ b/sappyspellbook/wizard/index.html
@@ -11,6 +11,8 @@
 
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-7JR53Y27TN"></script>
+<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"></script>
+
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -561,6 +563,7 @@
          </table>
        </div>
     
+      <div hidden id="qrcode"></div>
 
   <div id="toastMessage" class="toast"></div>
 <!-- partial -->

--- a/sappyspellbook/wizard/script.js
+++ b/sappyspellbook/wizard/script.js
@@ -187,6 +187,15 @@ function toggleIncants(){
 }
 /*##################################*/
 function toggleList(incantOnly){
+  const qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: window.location.href,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1994,14 +2003,15 @@ function printCards(){
     toggleIncants();
   }
   if(document.title == "Wizard Spellbook"){
-    textToSave = "Wizard Level " + document.getElementById("reqLevel").value + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = "Wizard Level " + document.getElementById("reqLevel").value + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   else{
-    textToSave = document.title + " \n(Wizard Level " + document.getElementById("reqLevel").value + ")" + document.getElementById("ltp").innerText + " \n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
+    textToSave = document.title + " (Wizard Level " + document.getElementById("reqLevel").value + ")" + "\n   Level 1 \n" + document.getElementById("lvl1List").innerText + "\n   Level 2 \n" + document.getElementById("lvl2List").innerText + "\n   Level 3 \n" + document.getElementById("lvl3List").innerText + "\n   Level 4 \n" + document.getElementById("lvl4List").innerText + "\n   Level 5 \n" + document.getElementById("lvl5List").innerText + "\n   Level 6 \n" + document.getElementById("lvl6List").innerText;
   }
   const textData = textToSave;
 
-  const lines = textData.split('\n');
+  const lines = textData.split('\n'); // this is "lines" but it's not column-limited! Limit to 69 (nice) characters to prevent wrap
+
   const title = lines[0];
   const entries = [];
 
@@ -2010,9 +2020,9 @@ function printCards(){
     const line = lines[i].trim();
     if (line.startsWith('Level')) {
       currentLevel = line;
-    } else if (line.includes('Experienced')) {
+    } else if (line.includes('Experienced')) { // roll purchases of Experienced into the spell it's purchased for to avoide wasting space on the card
     } else if (line.startsWith('-')) {
-      if (entries.length > 0) {
+    if (entries.length > 0) {
         entries[entries.length - 1].flavor = line.slice(1).trim();
       }
     } else if (line) {
@@ -2020,48 +2030,60 @@ function printCards(){
     }
   }
 
-// collapsing armor so it doesn't eat two lines
   for (let i = 0; i < entries.length; i++) {
-    for (let j = i + 1; j < entries.length; j++) {
-      if (entries[i].text === entries[j].text) {
-        // replace first instance with 2x iff there are two
-        entries[i] = { level: entries[i].level, text: entries[i].text.replace("1", "2"), flavor: entries[i].flavor };
-        entries.splice(j,j)
-      }
-    }
-    if ([entries[i].text + entries[i].flavor].length + 3 >79){
+   txt = entries[i].text
+   flv = entries[i].flavor
+   if (txt.length + flv.length + 6 > 66){
      entries[i].lines = 2
    } else {entries[i].lines = 1}
  }
 
 
 // Split onto up to 3 cards
- numchunks = 3
-maxchunlines = 10 // this may be right for 9pt
+numchunks = 3
+maxchunlines = 13 // this may be right for 9pt
 chunks = []
 currchlines = 0
 cut = []
 for (let i = 0; i < entries.length; i++) {
   currchlines = currchlines + entries[i].lines
-  // console.log(currchlines)
+  console.log(currchlines)
   if (currchlines >= maxchunlines){
     cut.push(i)
-    // console.log(i)
+    console.log(entries[i].lines)
     currchlines = entries[i].lines
   }
 }
 console.log(cut)
 console.log(cut.length)
 
+chunks.push({num: 1, max: 1, qr: true, entries: []})
+
 if (cut.length == 1){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1])];
+  divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 2, qr: false, entries: divs[1]})
+  chunks[0].max = 2
 }
 else if (cut.length == 2){
-  chunks = [entries.slice(0, cut[0]), entries.slice(cut[0], cut[1]), entries.slice(cut[1])];
-} 
+divs = [entries.slice(0, cut[0]-1), entries.slice(cut[0]-1, cut[1]-1), entries.slice(cut[1]-1)];
+  chunks[0].entries = divs[0]
+  chunks.push({num: 2, max: 3, qr: false, entries: divs[1]})
+  chunks.push({num: 3, max: 3, qr: false, entries: divs[2]})
+  chunks[0].max = 3} 
 else {
-  chunks = [entries];
+divs = [entries];
+chunks[0].entries = divs
 }
+console.log(chunks)
+
+
+
+// get the qr and put it where it goes 
+var qr = document.getElementById('qrcode')
+var qrcanvas = qr.querySelector('canvas');
+console.log(qrcanvas) // wtf
+qrImageSrc = qrcanvas.toDataURL();
 
 const htmlContent = `
 <html>
@@ -2100,9 +2122,10 @@ const htmlContent = `
 <body>
   ${chunks.map(chunk => `
     <div class="card">
-      <div class="title">${title}</div>
-    ${chunk.map(entry => `
-        <div class="entry">${entry.text}${entry.flavor ? ' - ' + entry.flavor : ''}</div>
+    <img ${chunk.num == 1 ? '' : 'hidden '}style="float: right; width: 60px; height: auto" src=${qrImageSrc}></img>
+      <div class="title"><u>${title}</u>  ${chunk.num}/${chunk.max}</div> 
+      ${chunk.entries.map(entry => `
+        <div class="entry"><b>${entry.text}</b><i>${entry.flavor ? ' - ' + entry.flavor : ''}</i></div>
       `).join('')}
     </div>
     `).join('')}


### PR DESCRIPTION
Here I added a QR code to the first card that points to the URL of the page at generation time (aka saves your list so you can scan the QR and go right to the site with your list loaded, in case a Reeve ever has a question about points or validity, or you just want to change something and print a fresh set). 

I also improved the computation of how many lines of text are in each ability purchased and therefore how many things fit on each card (you should need the third card more rarely now, even with the QR code taking up space). I haven't tested every possible combination of spells, experienced, etc., so there might be a list or two out there that would overflow a card border; hopefully those are very few, though.

I also added a page number out of max in the title line of each card (e.g., 1/2, 2/2), to help keep things orderly. 

Additionally, the formatting has been updated to make the cards easier to use on the field by emphasizing abilities and usage over incantations.

LMK if you see anything you want me to change, and obvs maintainers can make edits directly.