### PR TITLE
qrcode wasn't regenerating if you edited your list

### DIFF
--- a/sappyspellbook/bard/script.js
+++ b/sappyspellbook/bard/script.js
@@ -190,15 +190,6 @@ function toggleIncants(){
 /*##################################*/
 function toggleList(incantOnly){
 
-  const qrcode = new QRCode(document.getElementById('qrcode'), {
-    text: window.location.href,
-    width: 128,
-    height: 128,
-    colorDark : '#000',
-    colorLight : '#fff',
-    correctLevel : QRCode.CorrectLevel.L,
-    typenumber: 4
-  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1772,6 +1763,20 @@ function saveList(){
 }
 
 function printCards(){
+  const elementToRemove = document.getElementById('qrcode');
+  if (elementToRemove) {
+      elementToRemove.replaceChildren();
+  }
+  qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: document.URL,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
+
   let textToSave = "";
   if (showIncants != true){
     toggleIncants();

--- a/sappyspellbook/druid/script.js
+++ b/sappyspellbook/druid/script.js
@@ -152,15 +152,6 @@ function toggleIncants(){
 /*##################################*/
 function toggleList(incantOnly){
 
-  const qrcode = new QRCode(document.getElementById('qrcode'), {
-    text: window.location.href,
-    width: 128,
-    height: 128,
-    colorDark : '#000',
-    colorLight : '#fff',
-    correctLevel : QRCode.CorrectLevel.L,
-    typenumber: 4
-  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1630,6 +1621,20 @@ function saveList(){
 }
 
 function printCards(){
+  
+  const elementToRemove = document.getElementById('qrcode');
+  if (elementToRemove) {
+      elementToRemove.replaceChildren();
+  }
+  qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: document.URL,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
   let textToSave = "";
   if (showIncants != true){
     toggleIncants();

--- a/sappyspellbook/healer/script.js
+++ b/sappyspellbook/healer/script.js
@@ -187,15 +187,6 @@ function toggleIncants(){
 }
 /*##################################*/
 function toggleList(incantOnly){
-  const qrcode = new QRCode(document.getElementById('qrcode'), {
-    text: window.location.href,
-    width: 128,
-    height: 128,
-    colorDark : '#000',
-    colorLight : '#fff',
-    correctLevel : QRCode.CorrectLevel.L,
-    typenumber: 4
-  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1866,6 +1857,21 @@ function saveList(){
 }
 
 function printCards(){
+  
+  const elementToRemove = document.getElementById('qrcode');
+  if (elementToRemove) {
+      elementToRemove.replaceChildren();
+  }
+  qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: document.URL,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
+
   let textToSave = "";
   if (showIncants != true){
     toggleIncants();

--- a/sappyspellbook/wizard/script.js
+++ b/sappyspellbook/wizard/script.js
@@ -187,15 +187,6 @@ function toggleIncants(){
 }
 /*##################################*/
 function toggleList(incantOnly){
-  const qrcode = new QRCode(document.getElementById('qrcode'), {
-    text: window.location.href,
-    width: 128,
-    height: 128,
-    colorDark : '#000',
-    colorLight : '#fff',
-    correctLevel : QRCode.CorrectLevel.L,
-    typenumber: 4
-  });
   var tables = [];
   var lists = [];
   var levelList = ["", "", "", "", "", "", ""];
@@ -1998,6 +1989,21 @@ function saveList(){
 }
 
 function printCards(){
+  
+  const elementToRemove = document.getElementById('qrcode');
+  if (elementToRemove) {
+      elementToRemove.replaceChildren();
+  }
+  qrcode = new QRCode(document.getElementById('qrcode'), {
+    text: document.URL,
+    width: 128,
+    height: 128,
+    colorDark : '#000',
+    colorLight : '#fff',
+    correctLevel : QRCode.CorrectLevel.L,
+    typenumber: 4
+  });
+
   let textToSave = "";
   if (showIncants != true){
     toggleIncants();


### PR DESCRIPTION
Someone pointed out that if you made a list, then hit Toggle List, it generated the qrcode from the URL, but, if you then toggled back and edited the list, the QR Code element never updates to the new URL, so your QR on your printed cards is pointing to the previous version of the list!

I moved the QR generation to inside of the Print Cards call and it starts off by clearing the old one if it exists, so now the codes should work properly for edited lists.